### PR TITLE
Avoid UnicodeDecodeErrors caused by mixing UTF-8 text and Unicode strings

### DIFF
--- a/django_tablib/base.py
+++ b/django_tablib/base.py
@@ -24,7 +24,7 @@ class BaseDataset(tablib.Dataset):
         if t is str:
             return value
         elif t in [datetime.date, datetime.datetime]:
-            return date(value, 'SHORT_DATE_FORMAT')
+            return date(value, 'SHORT_DATE_FORMAT').encode("utf-8")
         else:
             return smart_unicode(value).encode('utf8')
     


### PR DESCRIPTION
I ran into an issue with some Russian content where the data in question was encoded as UTF-8 but ran into problems when tablib does a "\n".join() on the row because all of my date columns were unicode strings, which caused everything to be promoted and thus caused decode errors handling the UTF-8 escaped data.

This change fixes this issue but it feels like a better fix would be making django-tablib feed tablib Unicode strings and making tablib do UTF-8 encoding when needed at the time of output.
