### PR TITLE
With Django 1.5, an import causes a DeprecationWarning

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Other contributions by
 - Brad Montgomery
 - Ryan Choi
 - Anna Callahan
+- Antti Kaihola

--- a/django_tablib/admin.py
+++ b/django_tablib/admin.py
@@ -27,7 +27,10 @@ class TablibAdmin(admin.ModelAdmin):
         super(TablibAdmin, self).__init__(*args, **kwargs)
 
     def get_urls(self):
-        from django.conf.urls.defaults import patterns, url
+        try:
+            from django.conf.urls import patterns, url
+        except ImportError:  # Django <1.4
+            from django.conf.urls.defaults import patterns, url
 
         def wrap(view):
             def wrapper(*args, **kwargs):


### PR DESCRIPTION
I'm running django-tablib with [the Django 1.5 release candidate](https://www.djangoproject.com/weblog/2013/jan/04/15-rc-1/). It logs a deprecation warning from django-tablib. If I change warnings to errors and enable tracebacks, I see:

```
File "django_tablib/admin.py", line 30, in get_urls
  from django.conf.urls.defaults import patterns, url
File "django/conf/urls/defaults.py", line 3, in <module>
  DeprecationWarning)

DeprecationWarning: django.conf.urls.defaults is deprecated; use django.conf.urls instead
```
