### PR TITLE
Try to import update_wrapper from functools first

### DIFF
--- a/django_tablib/admin.py
+++ b/django_tablib/admin.py
@@ -3,7 +3,11 @@ from django.contrib import admin
 from django.contrib.admin.views.main import ChangeList
 from django.core.urlresolvers import reverse
 from django.http import Http404
-from django.utils.functional import update_wrapper
+try:
+    from functools import update_wrapper
+except ImportError:
+    from django.utils.functional import update_wrapper
+
 from django_tablib.views import export
 import django
 


### PR DESCRIPTION
`update_wrapper` was removed from django.utils.functional in 1.6 (https://github.com/django/django/commit/876fc391) as it's part of the standard library in Python 2.5+.
