### PR TITLE
Build dicts in a Python 2.6 compatible way

### DIFF
--- a/django_tablib/models.py
+++ b/django_tablib/models.py
@@ -77,16 +77,16 @@ class ModelDataset(BaseDataset):
         if self._meta.exclude:
             included = filter(lambda x: x not in self._meta.exclude, included)
 
-        self.fields = {field: Field() for field in included}
+        self.fields = dict((field, Field()) for field in included)
+
         self.fields.update(deepcopy(self.base_fields))
 
         fields = [
             field.attribute or name for name, field in self.fields.items()
         ]
-        header_dict = {
-            field.header or name: field.attribute or name
-            for name, field in self.fields.items()
-        }
+        header_dict = dict((field.header or name, field.attribute or name) for
+            name, field in self.fields.items())
+
         header_list = header_dict.keys()
 
         self.attr_list = fields


### PR DESCRIPTION
The dict comprehensions don't work on Python 2.6.
So in case dropping 2.6 wasn't intended, this PR should restore compatibility.
 
