### PR TITLE
BaseExportView, class based view for programmable exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 *.pyc
 db.sqlite3
+
+# PyCharm
+.idea/*
+
+# Mac OS X
+.DS_Store


### PR DESCRIPTION
This base class enables you to write customized exports, using this strategy:
1. Inherit from ListView to profit from the model/queryset options already provided by Django.
2. Specify columns to be retrieved, either by name or by name, accessor combination.
3. Allow render_COLUMNNAME methods to provide customized rendering.

I hope this is of some use.
