### PR TITLE
Don't recalculate attributes

### DIFF
--- a/django_tablib/models.py
+++ b/django_tablib/models.py
@@ -80,16 +80,10 @@ class ModelDataset(BaseDataset):
         self.fields = {field: Field() for field in included}
         self.fields.update(deepcopy(self.base_fields))
 
-        fields = [
-            field.attribute or name for name, field in self.fields.items()
-        ]
-        header_dict = {
+        self.header_dict = {
             field.header or name: field.attribute or name
             for name, field in self.fields.items()
         }
-        header_list = header_dict.keys()
-
-        self.attr_list = fields
-        self.header_dict = header_dict
-        self.header_list = header_list
+        self.header_list = self.header_dict.keys()
+        self.attr_list = [self.header_dict[h] for h in self.header_list]
         super(ModelDataset, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Finding `attr_list` the way we do in `master` runs the risk of `attr_list` and `header_list` getting out of sync and producing exports where headers and columns do not match. This approach is also slightly more compact and readable.