### PR TITLE
Defer character encoding to tablib

### DIFF
--- a/django_tablib/base.py
+++ b/django_tablib/base.py
@@ -16,8 +16,6 @@ mimetype_map = {
 
 class BaseDataset(tablib.Dataset):
 
-    encoding = 'utf-8'
-
     def __init__(self):
         data = map(self._getattrs, self.queryset)
         super(BaseDataset, self).__init__(headers=self.header_list, *data)
@@ -25,19 +23,15 @@ class BaseDataset(tablib.Dataset):
     def _cleanval(self, value, attr):
         if callable(value):
             value = value()
-        elif value is None or unicode(value) == u"None":
+        elif value is None or tablib.compat.unicode(value) == u"None":
             value = ""
 
-        t = type(value)
-        if t is str:
-            return value
-        elif t is bool:
+        if isinstance(value, bool):
             value = _("Y") if value else _("N")
-            return smart_unicode(value).encode(self.encoding)
-        elif t in [datetime.date, datetime.datetime]:
-            return date(value, 'SHORT_DATE_FORMAT').encode(self.encoding)
+        elif isinstance(value, (datetime.date, datetime.datetime)):
+            value = date(value, 'SHORT_DATE_FORMAT')
 
-        return smart_unicode(value).encode(self.encoding)
+        return smart_unicode(value)
 
     def _getattrs(self, obj):
         attrs = []

--- a/django_tablib/base.py
+++ b/django_tablib/base.py
@@ -2,7 +2,7 @@ import datetime
 import tablib
 
 from django.template.defaultfilters import date
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 mimetype_map = {
@@ -31,7 +31,7 @@ class BaseDataset(tablib.Dataset):
         elif isinstance(value, (datetime.date, datetime.datetime)):
             value = date(value, 'SHORT_DATE_FORMAT')
 
-        return smart_unicode(value)
+        return force_text(value)
 
     def _getattrs(self, obj):
         attrs = []


### PR DESCRIPTION
The previous logic ensured that all strings were bytestrings.
Unfortuantely, this breaks with e.g. the XSLX output support any time
you emit data which contains a non-ASCII character.

This patch simply ensures that everything returned is a Unicode instance
and lets tablib or other downstream consumers decide how to encode it.

Additionally, it uses tablib.compat.unicode instead of the unicode()
built-in for future compatibility with Python 3.