### PR TITLE
py3 doesn't have smart_unicode, but py2.7 does. this fixes py3.4 use

### DIFF
--- a/django_tablib/base.py
+++ b/django_tablib/base.py
@@ -2,7 +2,13 @@ import datetime
 import tablib
 
 from django.template.defaultfilters import date
-from django.utils.encoding import smart_unicode
+
+import sys
+if sys.version_info[0] == 3:
+    from django.utils.encoding import smart_text as smart_unicode
+else:
+    from django.utils.encoding import smart_unicode
+
 from django.utils.translation import ugettext_lazy as _
 
 mimetype_map = {


### PR DESCRIPTION
Same bug as https://github.com/ui/django-html_sanitizer/pull/9
