### PR TITLE
Python 3 fix

### DIFF
--- a/django_tablib/base.py
+++ b/django_tablib/base.py
@@ -2,7 +2,7 @@ import datetime
 import tablib
 
 from django.template.defaultfilters import date
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text
 from django.utils.translation import ugettext_lazy as _
 
 mimetype_map = {


### PR DESCRIPTION
Python 2’s unicode type was renamed str in Python 3, str() was renamed bytes, and basestring disappeared. six provides tools to deal with these changes.

Django also contains several string related classes and functions in the django.utils.encoding and django.utils.safestring modules. Their names used the words str, which doesn’t mean the same thing in Python 2 and Python 3, and unicode, which doesn’t exist in Python 3. In order to avoid ambiguity and confusion these concepts were renamed bytes and text.

Here are the name changes in django.utils.encoding:
Old name 	New name
smart_str 	smart_bytes
smart_unicode 	smart_text
force_unicode 	force_text

For backwards compatibility, the old names still work on Python 2. Under Python 3, smart_str is an alias for smart_text.

For forwards compatibility, the new names work as of Django 1.4.2.

Source : https://docs.djangoproject.com/en/1.8/topics/python3/