### PR TITLE
Fix Django 1.10 and 2.0 compatibility

### DIFF
--- a/django_tablib/admin/__init__.py
+++ b/django_tablib/admin/__init__.py
@@ -5,7 +5,14 @@ import datetime
 import django
 from distutils.version import LooseVersion
 from django.contrib import admin
-from django.core.urlresolvers import reverse
+
+try:
+    # Django <= 1.10
+    from django.core.urlresolvers import reverse
+except ImportError:
+    # Django >= 2.0
+    from django.urls import reverse
+
 from django.http import Http404
 
 

--- a/django_tablib/datasets.py
+++ b/django_tablib/datasets.py
@@ -20,10 +20,13 @@ class SimpleDataset(BaseDataset):
                 # django < 1.9
                 field_names = v_qs.field_names
             headers.extend(field_names)
-            
+
             if hasattr(v_qs.query, 'aggregate_select'):
                 # Django < 1.10
                 headers.extend(v_qs.query.aggregate_select)
+            elif hasattr(v_qs.query, 'annotation_select'):
+                # Django >= 1.10
+                headers.extend(v_qs.query.annotation_select)
 
             self.header_list = headers
             self.attr_list = headers

--- a/django_tablib/datasets.py
+++ b/django_tablib/datasets.py
@@ -20,7 +20,10 @@ class SimpleDataset(BaseDataset):
                 # django < 1.9
                 field_names = v_qs.field_names
             headers.extend(field_names)
-            headers.extend(v_qs.query.aggregate_select)
+            
+            if hasattr(v_qs.query, 'aggregate_select'):
+                # Django < 1.10
+                headers.extend(v_qs.query.aggregate_select)
 
             self.header_list = headers
             self.attr_list = headers

--- a/testproject/requirements.txt
+++ b/testproject/requirements.txt
@@ -1,2 +1,12 @@
-Django==1.6
+Django==1.8
+django-tablib==3.2
+et-xmlfile==1.0.1
+jdcal==1.4
+odfpy==1.3.6
+openpyxl==2.5.3
+PyYAML==3.12
+six==1.11.0
 tablib==0.12.1
+unicodecsv==0.14.1
+xlrd==1.1.0
+xlwt==1.3.0

--- a/testproject/requirements.txt
+++ b/testproject/requirements.txt
@@ -1,2 +1,2 @@
 Django==1.6
-tablib==0.9.11
+tablib==0.12.1


### PR DESCRIPTION
- Handle "aggregate_select" deprecated method from django.db.sql.query.Query.
- Make "reverse" import compatible for both versions 1.10 and 2.0.